### PR TITLE
fix: update h1 style

### DIFF
--- a/src/style/global.sass
+++ b/src/style/global.sass
@@ -4,7 +4,7 @@
 @import '_dark-mode-switcher.sass'
 @import '_arrow-animation.sass'
 @import '_hamburger-animation.sass'
-  
+
 .navbar
   position: relative
   border-bottom: 1px solid $clr_soft
@@ -113,6 +113,10 @@
     max-width: 780px
     padding: 1.5rem
     flex: 2
+    h1
+      font-size: clamp(1.94rem,1.69rem + 1.29vw,2.69rem)
+      font-weight: 600
+      line-height: 1.25
     @include lg 
       margin: 0 auto
     @include md 


### PR DESCRIPTION
# **Issue(Bug) Pull Request**

### **Checklist**

Ensure that your `pull request` has followed all the steps below:

- [x] Code compilation
- [x] Bug has fixed
- [x] All tests passing

---

## 🚀 **Title**

fix `h1` style lossing when build (#10)

## 🚀 **Root Cause**

tailwindcss base style was cover the default css (resetCSS was covered by tailwindcss base style)

## 🚀 **Description**

it cause the title of the posts lost

## 🚀 **Changes**

add `h1` style to `global.sass` file to enable `h1` with style